### PR TITLE
feat: Add OpenAI Codex hooks support with unified interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A system that automatically applies different "personas" to Claude Code sessions
 - 📝 **Customizable** - Create and edit custom personas easily
 - 🎯 **Consistent interactions** - Maintain unified response styles throughout projects
 - 🔊 **Voice synthesis** - Optional text-to-speech for assistant messages
+- 🤖 **Multi-platform support** - Works with both Claude Code and OpenAI Codex
 
 ## Installation
 
@@ -51,7 +52,9 @@ ccpersona list
 ccpersona set zundamon
 ```
 
-3. **Configure Claude Code hook**
+3. **Configure hooks for your AI coding assistant**
+
+#### For Claude Code
 
 Add the following to your Claude Code settings file (e.g., `~/.claude/settings.json`):
 
@@ -92,7 +95,18 @@ Add the following to your Claude Code settings file (e.g., `~/.claude/settings.j
 }
 ```
 
-Now the persona will be applied automatically when you submit prompts in Claude Code.
+#### For OpenAI Codex
+
+Add the following to your Codex config file (`~/.codex/config.toml`):
+
+```toml
+[notify]
+# Use unified hook command that auto-detects Claude Code or Codex
+command = "ccpersona"
+args = ["codex-notify"]
+```
+
+Now the persona will be applied automatically when you submit prompts.
 
 ## Usage
 
@@ -128,6 +142,10 @@ ccpersona config -g     # Edit global config
 ccpersona hook                    # UserPromptSubmit hook (alias: user_prompt_submit_hook)
 ccpersona voice                   # Stop hook (alias: stop_hook)
 ccpersona notify                  # Notification hook (alias: notification_hook)
+
+# Execute as unified hook (works for both Claude Code and Codex)
+ccpersona codex-notify            # Unified hook (alias: codex_hook)
+                                  # Auto-detects and handles both platforms
 
 # Voice synthesis (expects JSON hook event from stdin by default)
 ccpersona voice                   # Read Stop hook JSON event from stdin
@@ -267,6 +285,8 @@ git push origin --tags
 
 ### How Hooks Work
 
+#### Claude Code Integration
+
 ccpersona integrates with Claude Code through the UserPromptSubmit hook:
 
 1. Configure Claude Code to run `ccpersona hook` on each prompt submission
@@ -274,10 +294,30 @@ ccpersona integrates with Claude Code through the UserPromptSubmit hook:
 3. If found and it's a new session, the persona instructions are output
 4. Claude Code receives these instructions and adjusts its behavior accordingly
 
+#### OpenAI Codex Integration
+
+ccpersona integrates with OpenAI Codex through the notify hook:
+
+1. Configure Codex to run `ccpersona codex-notify` on agent-turn-complete events
+2. When an agent turn completes, ccpersona receives the event in JSON format
+3. The unified hook interface automatically detects whether it's from Claude Code or Codex
+4. Appropriate actions (voice synthesis, notifications) are performed based on the event type
+
+#### Unified Hook Interface
+
+The `codex-notify` command provides a unified interface that automatically detects and handles events from both Claude Code and OpenAI Codex:
+
+- **Auto-detection**: Analyzes the JSON structure to determine the source platform
+- **Codex events**: Handles `agent-turn-complete` events with turn completion notifications
+- **Claude Code events**: Routes `UserPromptSubmit`, `Stop`, and `Notification` events to appropriate handlers
+- **Persona support**: Applies personas for both platforms using the same `.claude/persona.json` configuration
+- **Voice synthesis**: Works with both platforms using the configured voice engine
+
 This design provides:
 - Simple setup (works immediately after brew install)
 - Cross-platform compatibility (Windows/Mac/Linux)
-- Robust error handling (silent failures to avoid disrupting Claude Code)
+- Multi-platform AI assistant support (Claude Code and OpenAI Codex)
+- Robust error handling (silent failures to avoid disrupting the AI assistant)
 - Session tracking (prevents duplicate persona applications)
 - Advanced customization options
 

--- a/internal/hook/types.go
+++ b/internal/hook/types.go
@@ -55,6 +55,17 @@ type PreCompactEvent struct {
 	CompactMode string `json:"compact_mode"` // "manual" or "auto"
 }
 
+// CodexNotifyEvent represents the Codex notify hook event
+// See: https://github.com/openai/codex/blob/main/docs/config.md
+type CodexNotifyEvent struct {
+	Type                 string   `json:"type"`                   // "agent-turn-complete"
+	ThreadID             string   `json:"thread-id"`              // UUID of the thread
+	TurnID               int      `json:"turn-id"`                // Turn number
+	CWD                  string   `json:"cwd"`                    // Current working directory
+	InputMessages        []string `json:"input-messages"`         // User's input messages
+	LastAssistantMessage string   `json:"last-assistant-message"` // Model's final response
+}
+
 // ParseHookEvent reads and parses the hook event from stdin
 func ParseHookEvent(r io.Reader) (*HookEvent, error) {
 	var event HookEvent
@@ -113,4 +124,19 @@ func ReadStopEvent() (*StopEvent, error) {
 // ReadNotificationEvent is a convenience function to read Notification event from stdin
 func ReadNotificationEvent() (*NotificationEvent, error) {
 	return ParseNotificationEvent(os.Stdin)
+}
+
+// ParseCodexNotifyEvent reads and parses Codex notify event from stdin
+func ParseCodexNotifyEvent(r io.Reader) (*CodexNotifyEvent, error) {
+	var event CodexNotifyEvent
+	decoder := json.NewDecoder(r)
+	if err := decoder.Decode(&event); err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+// ReadCodexNotifyEvent is a convenience function to read Codex notify event from stdin
+func ReadCodexNotifyEvent() (*CodexNotifyEvent, error) {
+	return ParseCodexNotifyEvent(os.Stdin)
 }

--- a/internal/hook/unified_test.go
+++ b/internal/hook/unified_test.go
@@ -1,0 +1,148 @@
+package hook
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectAndParseCodexEvent(t *testing.T) {
+	jsonData := `{
+		"type": "agent-turn-complete",
+		"thread-id": "12345678-1234-1234-1234-123456789abc",
+		"turn-id": 5,
+		"cwd": "/home/user/project",
+		"input-messages": ["Fix the bug in main.go"],
+		"last-assistant-message": "I've fixed the bug by updating the error handling."
+	}`
+
+	reader := strings.NewReader(jsonData)
+	event, err := DetectAndParse(reader)
+	if err != nil {
+		t.Fatalf("Failed to parse Codex event: %v", err)
+	}
+
+	if event.Source != "codex" {
+		t.Errorf("Expected source 'codex', got '%s'", event.Source)
+	}
+
+	if event.SessionID != "12345678-1234-1234-1234-123456789abc" {
+		t.Errorf("Expected session ID '12345678-1234-1234-1234-123456789abc', got '%s'", event.SessionID)
+	}
+
+	if event.EventType != "agent-turn-complete" {
+		t.Errorf("Expected event type 'agent-turn-complete', got '%s'", event.EventType)
+	}
+
+	if len(event.UserInput) != 1 || event.UserInput[0] != "Fix the bug in main.go" {
+		t.Errorf("Unexpected user input: %v", event.UserInput)
+	}
+
+	if event.AIResponse != "I've fixed the bug by updating the error handling." {
+		t.Errorf("Unexpected AI response: %s", event.AIResponse)
+	}
+
+	if !event.IsCodex() {
+		t.Error("Expected IsCodex() to return true")
+	}
+
+	if event.IsClaudeCode() {
+		t.Error("Expected IsClaudeCode() to return false")
+	}
+
+	codexEvent, ok := event.GetCodexEvent()
+	if !ok {
+		t.Error("Expected to get Codex event")
+	}
+
+	if codexEvent.TurnID != 5 {
+		t.Errorf("Expected turn ID 5, got %d", codexEvent.TurnID)
+	}
+}
+
+func TestDetectAndParseClaudeCodeUserPromptSubmit(t *testing.T) {
+	jsonData := `{
+		"session_id": "test-session-123",
+		"transcript_path": "/path/to/transcript.jsonl",
+		"cwd": "/home/user/project",
+		"hook_event_name": "UserPromptSubmit",
+		"prompt": "Help me fix this bug"
+	}`
+
+	reader := strings.NewReader(jsonData)
+	event, err := DetectAndParse(reader)
+	if err != nil {
+		t.Fatalf("Failed to parse Claude Code event: %v", err)
+	}
+
+	if event.Source != "claude-code" {
+		t.Errorf("Expected source 'claude-code', got '%s'", event.Source)
+	}
+
+	if event.SessionID != "test-session-123" {
+		t.Errorf("Expected session ID 'test-session-123', got '%s'", event.SessionID)
+	}
+
+	if event.EventType != "UserPromptSubmit" {
+		t.Errorf("Expected event type 'UserPromptSubmit', got '%s'", event.EventType)
+	}
+
+	if len(event.UserInput) != 1 || event.UserInput[0] != "Help me fix this bug" {
+		t.Errorf("Unexpected user input: %v", event.UserInput)
+	}
+
+	if !event.IsClaudeCode() {
+		t.Error("Expected IsClaudeCode() to return true")
+	}
+
+	if event.IsCodex() {
+		t.Error("Expected IsCodex() to return false")
+	}
+}
+
+func TestDetectAndParseClaudeCodeNotification(t *testing.T) {
+	jsonData := `{
+		"session_id": "test-session-456",
+		"transcript_path": "/path/to/transcript.jsonl",
+		"cwd": "/home/user/project",
+		"hook_event_name": "Notification",
+		"message": "Task completed successfully"
+	}`
+
+	reader := strings.NewReader(jsonData)
+	event, err := DetectAndParse(reader)
+	if err != nil {
+		t.Fatalf("Failed to parse Claude Code notification: %v", err)
+	}
+
+	if event.Source != "claude-code" {
+		t.Errorf("Expected source 'claude-code', got '%s'", event.Source)
+	}
+
+	if event.EventType != "Notification" {
+		t.Errorf("Expected event type 'Notification', got '%s'", event.EventType)
+	}
+
+	if event.AIResponse != "Task completed successfully" {
+		t.Errorf("Expected AI response 'Task completed successfully', got '%s'", event.AIResponse)
+	}
+}
+
+func TestDetectAndParseInvalidJSON(t *testing.T) {
+	jsonData := `{"invalid json`
+
+	reader := strings.NewReader(jsonData)
+	_, err := DetectAndParse(reader)
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}
+
+func TestDetectAndParseUnknownFormat(t *testing.T) {
+	jsonData := `{"unknown_field": "value"}`
+
+	reader := strings.NewReader(jsonData)
+	_, err := DetectAndParse(reader)
+	if err == nil {
+		t.Error("Expected error for unknown format, got nil")
+	}
+}


### PR DESCRIPTION
## Overview

This PR adds support for OpenAI Codex hooks while maintaining full backward compatibility with Claude Code. The implementation introduces a unified hook interface that automatically detects and handles events from both platforms.

## Motivation

Currently, ccpersona only supports Claude Code hooks. With the emergence of OpenAI Codex as another AI coding assistant, users want to use the same persona management system across multiple platforms. This PR enables that capability.

## What's Changed

### 🎯 Core Features

- **Unified Hook Interface**: Auto-detects platform from JSON event structure
- **Codex Event Support**: Handles `agent-turn-complete` events from OpenAI Codex
- **New CLI Command**: `codex-notify` works seamlessly with both platforms
- **Shared Configuration**: Same `.claude/persona.json` for both platforms

### 📁 Files Changed

#### New Files
- `internal/hook/unified.go` - Unified event handling with auto-detection logic
- `internal/hook/unified_test.go` - Comprehensive test suite for both platforms

#### Modified Files
- `internal/hook/types.go` - Added `CodexNotifyEvent` structure and parsers
- `cmd/main.go` - Added `codex-notify` command and platform-specific handlers
- `README.md` - Added Codex setup instructions and multi-platform feature
- `CLAUDE.md` - Updated architecture documentation

### 🔧 Technical Implementation

#### Auto-Detection Logic
```go
// Detects platform by analyzing JSON structure
if _, hasType := generic["type"]; hasType {
    if typeVal == "agent-turn-complete" {
        // Codex event
    }
}
if _, hasHookEventName := generic["hook_event_name"]; hasHookEventName {
    // Claude Code event
}
```

#### Event Flow
1. Hook receives JSON via stdin
2. `DetectAndParse()` identifies the platform
3. Event is normalized to `UnifiedHookEvent`
4. Platform-specific handler processes the event
5. Shared functionality (persona, voice) is applied

## Configuration Examples

### For OpenAI Codex

Add to `~/.codex/config.toml`:
```toml
[notify]
command = "ccpersona"
args = ["codex-notify"]
```

### For Claude Code (Unchanged)

Existing configuration continues to work:
```json
{
  "hooks": {
    "UserPromptSubmit": [
      {
        "hooks": [{"type": "command", "command": "ccpersona hook"}]
      }
    ]
  }
}
```

## Testing

### Test Coverage
- ✅ All existing tests pass
- ✅ New unified interface tests (5 test cases)
- ✅ Manual testing with both event formats
- ✅ Code coverage: 36.1% for hook package

### Test Cases
- Codex `agent-turn-complete` event parsing
- Claude Code `UserPromptSubmit` event parsing
- Claude Code `Notification` event parsing
- Invalid JSON handling
- Unknown format rejection

## Benefits

1. **Zero Breaking Changes**: Existing Claude Code users unaffected
2. **Future-Proof**: Easy to add support for more platforms
3. **Code Reuse**: Shared persona and voice functionality
4. **Simple Setup**: Single command works for both platforms
5. **Maintainability**: Unified interface reduces code duplication

## Migration Guide

**Existing Users**: No action needed! Your current setup continues to work.

**New Codex Users**: Simply add the configuration to `~/.codex/config.toml` as shown above.

## Related Documentation

- [OpenAI Codex Hooks Documentation](https://github.com/openai/codex/blob/main/docs/config.md)
- [Claude Code Hooks Documentation](https://docs.anthropic.com/en/docs/claude-code/hooks)

## Checklist

- [x] Code follows project conventions
- [x] Tests added and passing
- [x] Documentation updated (README.md, CLAUDE.md)
- [x] Backward compatibility maintained
- [x] Manual testing completed
- [x] No linting errors

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>