### PR TITLE
feat: add SessionStart hook support for persona application

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,29 @@ ccpersona is a persona management system that automatically applies different "p
 
 #### Claude Code Integration
 
-The system integrates with Claude Code via hooks:
-1. User configures Claude Code with `"user-prompt-submit": "ccpersona hook"`
-2. On session start, ccpersona checks for `.claude/persona.json` in the current directory
+The system integrates with Claude Code via hooks. **SessionStart is the recommended hook** as it's triggered once per session:
+
+**Recommended configuration (SessionStart):**
+```json
+{
+  "hooks": {
+    "session-start": ["ccpersona hook"]
+  }
+}
+```
+
+**Legacy configuration (UserPromptSubmit) - still supported:**
+```json
+{
+  "hooks": {
+    "user-prompt-submit": ["ccpersona hook"]
+  }
+}
+```
+
+The hook process:
+1. User configures Claude Code with the hook command
+2. On session start (or prompt submit for legacy), ccpersona checks for `.claude/persona.json`
 3. If found, applies the specified persona by outputting formatted instructions
 4. Session tracking prevents re-application during the same session
 

--- a/internal/hook/types.go
+++ b/internal/hook/types.go
@@ -55,6 +55,18 @@ type PreCompactEvent struct {
 	CompactMode string `json:"compact_mode"` // "manual" or "auto"
 }
 
+// SessionStartEvent represents the SessionStart hook event
+// Triggered when a Claude Code session starts or resumes
+type SessionStartEvent struct {
+	HookEvent
+}
+
+// SessionEndEvent represents the SessionEnd hook event
+// Triggered when a Claude Code session ends
+type SessionEndEvent struct {
+	HookEvent
+}
+
 // CodexNotifyEvent represents the Codex notify hook event
 // See: https://github.com/openai/codex/blob/main/docs/config.md
 type CodexNotifyEvent struct {
@@ -124,6 +136,36 @@ func ReadStopEvent() (*StopEvent, error) {
 // ReadNotificationEvent is a convenience function to read Notification event from stdin
 func ReadNotificationEvent() (*NotificationEvent, error) {
 	return ParseNotificationEvent(os.Stdin)
+}
+
+// ParseSessionStartEvent reads and parses SessionStart event from stdin
+func ParseSessionStartEvent(r io.Reader) (*SessionStartEvent, error) {
+	var event SessionStartEvent
+	decoder := json.NewDecoder(r)
+	if err := decoder.Decode(&event); err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+// ReadSessionStartEvent is a convenience function to read SessionStart event from stdin
+func ReadSessionStartEvent() (*SessionStartEvent, error) {
+	return ParseSessionStartEvent(os.Stdin)
+}
+
+// ParseSessionEndEvent reads and parses SessionEnd event from stdin
+func ParseSessionEndEvent(r io.Reader) (*SessionEndEvent, error) {
+	var event SessionEndEvent
+	decoder := json.NewDecoder(r)
+	if err := decoder.Decode(&event); err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+// ReadSessionEndEvent is a convenience function to read SessionEnd event from stdin
+func ReadSessionEndEvent() (*SessionEndEvent, error) {
+	return ParseSessionEndEvent(os.Stdin)
 }
 
 // ParseCodexNotifyEvent reads and parses Codex notify event from stdin

--- a/internal/hook/unified.go
+++ b/internal/hook/unified.go
@@ -114,6 +114,36 @@ func parseClaudeCodeEvent(data []byte, generic map[string]interface{}) (*Unified
 			RawEvent:   &event,
 		}, nil
 
+	case "SessionStart":
+		var event SessionStartEvent
+		if err := json.Unmarshal(data, &event); err != nil {
+			return nil, fmt.Errorf("failed to parse SessionStart event: %w", err)
+		}
+		return &UnifiedHookEvent{
+			Source:     "claude-code",
+			SessionID:  event.SessionID,
+			CWD:        event.CWD,
+			EventType:  hookEventName,
+			UserInput:  []string{},
+			AIResponse: "",
+			RawEvent:   &event,
+		}, nil
+
+	case "SessionEnd":
+		var event SessionEndEvent
+		if err := json.Unmarshal(data, &event); err != nil {
+			return nil, fmt.Errorf("failed to parse SessionEnd event: %w", err)
+		}
+		return &UnifiedHookEvent{
+			Source:     "claude-code",
+			SessionID:  event.SessionID,
+			CWD:        event.CWD,
+			EventType:  hookEventName,
+			UserInput:  []string{},
+			AIResponse: "",
+			RawEvent:   &event,
+		}, nil
+
 	default:
 		// For other Claude Code events, just parse as generic HookEvent
 		var event HookEvent

--- a/internal/hook/unified_test.go
+++ b/internal/hook/unified_test.go
@@ -127,6 +127,64 @@ func TestDetectAndParseClaudeCodeNotification(t *testing.T) {
 	}
 }
 
+func TestDetectAndParseClaudeCodeSessionStart(t *testing.T) {
+	jsonData := `{
+		"session_id": "session-start-123",
+		"transcript_path": "/path/to/transcript.jsonl",
+		"cwd": "/home/user/project",
+		"hook_event_name": "SessionStart"
+	}`
+
+	reader := strings.NewReader(jsonData)
+	event, err := DetectAndParse(reader)
+	if err != nil {
+		t.Fatalf("Failed to parse SessionStart event: %v", err)
+	}
+
+	if event.Source != "claude-code" {
+		t.Errorf("Expected source 'claude-code', got '%s'", event.Source)
+	}
+
+	if event.EventType != "SessionStart" {
+		t.Errorf("Expected event type 'SessionStart', got '%s'", event.EventType)
+	}
+
+	if event.SessionID != "session-start-123" {
+		t.Errorf("Expected session ID 'session-start-123', got '%s'", event.SessionID)
+	}
+
+	if event.CWD != "/home/user/project" {
+		t.Errorf("Expected CWD '/home/user/project', got '%s'", event.CWD)
+	}
+}
+
+func TestDetectAndParseClaudeCodeSessionEnd(t *testing.T) {
+	jsonData := `{
+		"session_id": "session-end-456",
+		"transcript_path": "/path/to/transcript.jsonl",
+		"cwd": "/home/user/project",
+		"hook_event_name": "SessionEnd"
+	}`
+
+	reader := strings.NewReader(jsonData)
+	event, err := DetectAndParse(reader)
+	if err != nil {
+		t.Fatalf("Failed to parse SessionEnd event: %v", err)
+	}
+
+	if event.Source != "claude-code" {
+		t.Errorf("Expected source 'claude-code', got '%s'", event.Source)
+	}
+
+	if event.EventType != "SessionEnd" {
+		t.Errorf("Expected event type 'SessionEnd', got '%s'", event.EventType)
+	}
+
+	if event.SessionID != "session-end-456" {
+		t.Errorf("Expected session ID 'session-end-456', got '%s'", event.SessionID)
+	}
+}
+
 func TestDetectAndParseInvalidJSON(t *testing.T) {
 	jsonData := `{"invalid json`
 


### PR DESCRIPTION
## Summary

Implements Issue #17: SessionStart hook support for persona application

### Changes
- Add `SessionStartEvent` and `SessionEndEvent` types in `internal/hook/types.go`
- Update unified hook detection in `internal/hook/unified.go`
- Update `handleHook` in `cmd/main.go` to process different event types
- Add tests for new event types
- Update `CLAUDE.md` with recommended configuration

### Why SessionStart?

| Aspect | SessionStart | UserPromptSubmit |
|--------|--------------|------------------|
| Trigger | Once per session | Every prompt |
| Session ID | Always provided | Available |
| Efficiency | High | Needs session tracking |
| Semantics | Perfect fit | Workaround |

### Configuration

**Recommended (SessionStart):**
```json
{
  "hooks": {
    "session-start": ["ccpersona hook"]
  }
}
```

**Legacy (still supported):**
```json
{
  "hooks": {
    "user-prompt-submit": ["ccpersona hook"]
  }
}
```

## Test Plan

- [x] Unit tests for SessionStart event parsing
- [x] Unit tests for SessionEnd event parsing
- [x] Build passes
- [x] All existing tests pass
- [ ] Manual test with Claude Code using `session-start` hook

### Manual Testing

```bash
# Build
make build

# Configure Claude Code (~/.claude/settings.json)
{
  "hooks": {
    "session-start": ["ccpersona hook"]
  }
}

# Start Claude Code session and verify persona is applied
```

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)