### PR TITLE
feat: Add Cursor support in init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A system that automatically applies different "personas" to Claude Code sessions
 - 📝 **Customizable** - Create and edit custom personas easily
 - 🎯 **Consistent interactions** - Maintain unified response styles throughout projects
 - 🔊 **Voice synthesis** - Optional text-to-speech for assistant messages
-- 🤖 **Multi-platform support** - Works with both Claude Code and OpenAI Codex
+- 🤖 **Multi-platform support** - Works with Claude Code, Cursor, and OpenAI Codex
 
 ## Installation
 
@@ -114,7 +114,29 @@ Add the following to your Codex config file (`~/.codex/config.toml`):
 [notify]
 # Use unified hook command that auto-detects Claude Code or Codex
 command = "ccpersona"
-args = ["codex-notify"]
+args = ["notify"]
+```
+
+#### For Cursor
+
+Run `ccpersona init` and select "Cursor" when prompted. This will create `.cursor/hooks.json` automatically:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "ccpersona hook"
+      }
+    ],
+    "stop": [
+      {
+        "command": "ccpersona voice"
+      }
+    ]
+  }
+}
 ```
 
 Now the persona will be applied automatically when you submit prompts.


### PR DESCRIPTION
## Summary

`ccpersona init` で AI アシスタント（Claude Code / Cursor / 両方）を選択できるようにしました。

### 変更内容

- init コマンドに AI アシスタント選択を追加
- Cursor 選択時に `.cursor/hooks.json` を自動生成
- README に Cursor セットアップ手順を追加

### 使い方

```
$ ccpersona init

🎭 ccpersona プロジェクト初期化

📝 利用可能なペルソナ:
   1. test

ペルソナを選択してください [1-1]: 1

🤖 AI アシスタントを選択してください:
   1. Claude Code
   2. Cursor
   3. 両方

選択 [1-3] (デフォルト: 1): 2

✅ 設定を作成しました:
   - .claude/persona.json
   - .cursor/hooks.json

   ペルソナ: test
```

### 生成される .cursor/hooks.json

```json
{
  "version": 1,
  "hooks": {
    "beforeSubmitPrompt": [
      {
        "command": "ccpersona hook"
      }
    ],
    "stop": [
      {
        "command": "ccpersona voice"
      }
    ]
  }
}
```

## Test plan

- [x] Build succeeds
- [x] Tests pass
- [x] Format and vet pass
- [ ] Manual test: init with Cursor selection

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)