### PR TITLE
feat: fallback to global persona config when project config not found

### DIFF
--- a/internal/persona/session.go
+++ b/internal/persona/session.go
@@ -139,12 +139,25 @@ func HandleSessionStart() error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
+	// Fallback to global config if project config not found
 	if config == nil {
-		log.Debug().Msg("No project persona configuration found")
+		log.Debug().Msg("No project persona configuration found, trying global config")
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		config, err = LoadConfig(homeDir)
+		if err != nil {
+			return fmt.Errorf("failed to load global config: %w", err)
+		}
+	}
+
+	if config == nil {
+		log.Debug().Msg("No persona configuration found (project or global)")
 		return nil
 	}
 
-	log.Info().Str("persona", config.Name).Msg("Found project persona configuration")
+	log.Info().Str("persona", config.Name).Msg("Found persona configuration")
 
 	// Apply the persona
 	manager, err := NewManager()


### PR DESCRIPTION
## Summary

- プロジェクトディレクトリに `.claude/persona.json` がない場合、`~/.claude/persona.json` にフォールバックするようになった

## Changes

- `internal/persona/session.go`: `HandleSessionStart` にグローバル設定へのフォールバックロジックを追加

## Test plan

- [ ] プロジェクトに `.claude/persona.json` がある場合 → プロジェクト設定が使われる
- [ ] プロジェクトになく、`~/.claude/persona.json` がある場合 → グローバル設定が使われる
- [ ] どちらもない場合 → ペルソナ適用なしで終了

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)