### PR TITLE
fix: プラットフォーム別設定ディレクトリを各エージェントの標準ディレクトリに変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,35 +113,47 @@ The `codex-notify` command provides a single interface for both platforms:
 ### Platform-Specific Configuration
 
 ccpersona supports platform-specific configuration files, allowing different personas for different AI assistants.
+Each platform uses its own standard configuration directory.
+
+#### Global Configuration Directories
+
+| Platform    | Global Config Path         |
+|-------------|---------------------------|
+| Claude Code | `~/.claude/persona.json`  |
+| Codex       | `~/.codex/persona.json`   |
+| Cursor      | `~/.cursor/persona.json`  |
 
 #### Configuration Fallback Hierarchy
 
-When loading configuration, ccpersona searches in this order (first match wins):
+**Claude Code:**
+1. `.claude/persona.json` (project)
+2. `~/.claude/persona.json` (global)
 
-1. **Project platform-specific**: `.claude/<platform>/persona.json`
-2. **Project common**: `.claude/persona.json`
-3. **Global platform-specific**: `~/.claude/<platform>/persona.json`
-4. **Global common**: `~/.claude/persona.json`
+**Codex:**
+1. `.claude/codex/persona.json` (project, platform-specific)
+2. `.claude/persona.json` (project, common)
+3. `~/.codex/persona.json` (global)
 
-Where `<platform>` is one of:
-- `claude-code` - Claude Code
-- `codex` - OpenAI Codex
-- `cursor` - Cursor IDE
+**Cursor:**
+1. `.claude/cursor/persona.json` (project, platform-specific)
+2. `.claude/persona.json` (project, common)
+3. `~/.cursor/persona.json` (global)
 
 #### Example Directory Structure
 
 ```
-~/.claude/
-├── persona.json              # Global default (all platforms)
-├── claude-code/
-│   └── persona.json          # Claude Code specific
-└── codex/
-    └── persona.json          # Codex specific
+# Global configs (each platform uses its own directory)
+~/.claude/persona.json        # Claude Code
+~/.codex/persona.json         # Codex
+~/.cursor/persona.json        # Cursor
 
+# Project configs (all in .claude/)
 ./your-project/.claude/
-├── persona.json              # Project default (all platforms)
-└── codex/
-    └── persona.json          # Project Codex specific
+├── persona.json              # Common (all platforms)
+├── codex/
+│   └── persona.json          # Codex specific
+└── cursor/
+    └── persona.json          # Cursor specific
 ```
 
 ### Key Design Decisions


### PR DESCRIPTION
## Summary

各 AI エージェントのグローバル設定を、それぞれの標準的な設定ディレクトリに変更。

### 変更前 (間違い)
```
~/.claude/codex/persona.json
~/.claude/cursor/persona.json
```

### 変更後 (正しい)
```
~/.claude/persona.json   # Claude Code
~/.codex/persona.json    # Codex
~/.cursor/persona.json   # Cursor
```

## Changes

- `GetGlobalConfigDir()` 関数を追加: プラットフォームごとのグローバル設定ディレクトリを返す
- `LoadConfigWithFallbackForPlatform()` を修正: 各プラットフォームの標準ディレクトリからグローバル設定を読み込む
- `LoadConfigForPlatform()` を修正: Claude Code はサブディレクトリを使わない
- テストを追加・更新
- CLAUDE.md のドキュメントを更新

## Fallback Hierarchy

**Claude Code:**
1. `.claude/persona.json` (project)
2. `~/.claude/persona.json` (global)

**Codex:**
1. `.claude/codex/persona.json` (project, platform-specific)
2. `.claude/persona.json` (project, common)
3. `~/.codex/persona.json` (global)

**Cursor:**
1. `.claude/cursor/persona.json` (project, platform-specific)
2. `.claude/persona.json` (project, common)
3. `~/.cursor/persona.json` (global)

## Test Plan

- [x] `TestGetGlobalConfigDir` - 各プラットフォームのディレクトリ取得
- [x] `TestLoadConfigForPlatform/ClaudeCodeDoesNotUseSubdirectory` - Claude Code がサブディレクトリを使わない
- [x] 既存のプラットフォーム設定テストが引き続き動作

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)