### PR TITLE
feat: Cursor hook 検出とイベント型の追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,13 +40,18 @@ ccpersona is a persona management system that automatically applies different "p
    - Manager handles persona CRUD operations and AI assistant integration
 
 2. **Hook System** (`internal/hook/`)
-   - **types.go**: Defines event types for both Claude Code and Codex
+   - **types.go**: Defines event types for Claude Code, Codex, and Cursor
      - Claude Code events: UserPromptSubmit, Stop, Notification, PreToolUse, PostToolUse, PreCompact
      - Codex events: CodexNotifyEvent (agent-turn-complete)
+     - Cursor events: sessionStart, beforeSubmitPrompt, stop (camelCase naming)
    - **unified.go**: Unified hook interface with auto-detection
-     - DetectAndParse(): Automatically detects Claude Code or Codex events from JSON
-     - UnifiedHookEvent: Normalized event structure for both platforms
+     - DetectAndParse(): Automatically detects Claude Code, Codex, or Cursor events from JSON
+     - UnifiedHookEvent: Normalized event structure for all platforms
      - Platform-specific handlers route events to appropriate logic
+   - **Platform Detection**:
+     - Codex: `"type": "agent-turn-complete"` field
+     - Cursor: `"conversation_id"` field (uses camelCase event names)
+     - Claude Code: `"session_id"` + `"hook_event_name"` fields (uses PascalCase event names)
 
 3. **Voice Synthesis** (`internal/voice/`)
    - Default: reads Stop hook JSON event from stdin (expects JSON with transcript_path)

--- a/internal/hook/types.go
+++ b/internal/hook/types.go
@@ -78,6 +78,36 @@ type CodexNotifyEvent struct {
 	LastAssistantMessage string   `json:"last-assistant-message"` // Model's final response
 }
 
+// CursorHookEvent represents the common hook event data from Cursor
+// See: https://cursor.com/docs/agent/hooks
+// Note: Cursor uses conversation_id instead of session_id, and camelCase event names
+type CursorHookEvent struct {
+	ConversationID string   `json:"conversation_id"`
+	GenerationID   string   `json:"generation_id"`
+	Model          string   `json:"model"`
+	HookEventName  string   `json:"hook_event_name"`
+	CursorVersion  string   `json:"cursor_version"`
+	WorkspaceRoots []string `json:"workspace_roots"`
+	UserEmail      string   `json:"user_email,omitempty"`
+	TranscriptPath string   `json:"transcript_path,omitempty"`
+}
+
+// CursorSessionStartEvent represents Cursor's sessionStart hook event
+type CursorSessionStartEvent struct {
+	CursorHookEvent
+}
+
+// CursorBeforeSubmitPromptEvent represents Cursor's beforeSubmitPrompt hook event
+type CursorBeforeSubmitPromptEvent struct {
+	CursorHookEvent
+	Prompt string `json:"prompt"`
+}
+
+// CursorStopEvent represents Cursor's stop hook event
+type CursorStopEvent struct {
+	CursorHookEvent
+}
+
 // ParseHookEvent reads and parses the hook event from stdin
 func ParseHookEvent(r io.Reader) (*HookEvent, error) {
 	var event HookEvent


### PR DESCRIPTION
## Summary

Cursor エディタの hook イベント検出を実装。

## 調査結果

Cursor は v1.7 から hook 機能を追加。Claude Code と同様に `hook_event_name` フィールドを持つが、以下の違いがある：

| 項目 | Claude Code | Cursor |
|------|-------------|--------|
| セッション ID | `session_id` | `conversation_id` |
| イベント名 | PascalCase (`SessionStart`) | camelCase (`sessionStart`) |
| プロンプト送信 | `UserPromptSubmit` | `beforeSubmitPrompt` |

## 実装内容

- `CursorHookEvent` および関連イベント型を追加
- `DetectAndParse()` で `conversation_id` の有無により Cursor を検出
- `parseCursorEvent()` で Cursor イベントをパース
- `IsCursor()`, `GetCursorEvent()` ヘルパーメソッド追加
- テスト追加
- CLAUDE.md ドキュメント更新

## プラットフォーム検出ロジック

```
1. type == "agent-turn-complete" → Codex
2. hook_event_name あり:
   - conversation_id あり → Cursor
   - session_id あり → Claude Code
3. それ以外 → エラー
```

## Test Plan

- [x] `TestDetectAndParseCursorSessionStart`
- [x] `TestDetectAndParseCursorBeforeSubmitPrompt`
- [x] `TestDetectAndParseCursorStop`
- [x] `TestGetCursorEvent`
- [x] 既存の Claude Code / Codex テストが引き続き動作

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)