### PR TITLE
fix: voice synthesis の空テキストエラーと読み上げ重複を修正

### DIFF
--- a/internal/voice/dedup.go
+++ b/internal/voice/dedup.go
@@ -1,0 +1,82 @@
+package voice
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const dedupDir = "ccpersona-voice"
+
+// DedupTracker tracks previously synthesized messages to avoid duplicates.
+// State is stored per session in the OS temp directory.
+type DedupTracker struct {
+	sessionID string
+	dir       string
+}
+
+// NewDedupTracker creates a tracker for the given session.
+func NewDedupTracker(sessionID string) *DedupTracker {
+	return &DedupTracker{
+		sessionID: sessionID,
+		dir:       filepath.Join(os.TempDir(), dedupDir),
+	}
+}
+
+// IsDuplicate returns true if this text was already synthesized in the current session.
+func (dt *DedupTracker) IsDuplicate(text string) bool {
+	hash := hashText(text)
+	stored, err := os.ReadFile(dt.markerPath())
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(stored)) == hash
+}
+
+// Record stores the hash of the synthesized text for this session.
+func (dt *DedupTracker) Record(text string) {
+	if err := os.MkdirAll(dt.dir, 0755); err != nil {
+		log.Debug().Err(err).Msg("Failed to create dedup directory")
+		return
+	}
+	hash := hashText(text)
+	if err := os.WriteFile(dt.markerPath(), []byte(hash), 0644); err != nil {
+		log.Debug().Err(err).Msg("Failed to write dedup marker")
+	}
+}
+
+// Cleanup removes markers older than 24 hours.
+func (dt *DedupTracker) Cleanup() {
+	entries, err := os.ReadDir(dt.dir)
+	if err != nil {
+		return
+	}
+
+	cutoff := time.Now().Add(-24 * time.Hour)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			_ = os.Remove(filepath.Join(dt.dir, entry.Name()))
+		}
+	}
+}
+
+func (dt *DedupTracker) markerPath() string {
+	return filepath.Join(dt.dir, dt.sessionID+".lastread")
+}
+
+func hashText(text string) string {
+	h := sha256.Sum256([]byte(text))
+	return fmt.Sprintf("%x", h)
+}

--- a/internal/voice/dedup_test.go
+++ b/internal/voice/dedup_test.go
@@ -1,0 +1,92 @@
+package voice
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDedupTracker_IsDuplicate(t *testing.T) {
+	dt := NewDedupTracker("test-session-dedup")
+	dt.dir = t.TempDir()
+
+	text := "こんにちはなのだ"
+
+	if dt.IsDuplicate(text) {
+		t.Error("Should not be duplicate on first call")
+	}
+
+	dt.Record(text)
+
+	if !dt.IsDuplicate(text) {
+		t.Error("Should be duplicate after recording")
+	}
+
+	if dt.IsDuplicate("別のテキスト") {
+		t.Error("Different text should not be duplicate")
+	}
+}
+
+func TestDedupTracker_DifferentSessions(t *testing.T) {
+	dir := t.TempDir()
+
+	dt1 := NewDedupTracker("session-1")
+	dt1.dir = dir
+	dt2 := NewDedupTracker("session-2")
+	dt2.dir = dir
+
+	text := "同じテキスト"
+	dt1.Record(text)
+
+	if !dt1.IsDuplicate(text) {
+		t.Error("Should be duplicate in session-1")
+	}
+	if dt2.IsDuplicate(text) {
+		t.Error("Should not be duplicate in session-2")
+	}
+}
+
+func TestDedupTracker_OverwritesPrevious(t *testing.T) {
+	dt := NewDedupTracker("test-overwrite")
+	dt.dir = t.TempDir()
+
+	dt.Record("first message")
+	dt.Record("second message")
+
+	if dt.IsDuplicate("first message") {
+		t.Error("First message should no longer be tracked after overwrite")
+	}
+	if !dt.IsDuplicate("second message") {
+		t.Error("Second message should be tracked")
+	}
+}
+
+func TestDedupTracker_Cleanup(t *testing.T) {
+	dir := t.TempDir()
+	dt := NewDedupTracker("current")
+	dt.dir = dir
+
+	// Create an old marker
+	oldPath := filepath.Join(dir, "old-session.lastread")
+	if err := os.WriteFile(oldPath, []byte("hash"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Set mod time to 25 hours ago
+	oldTime := time.Now().Add(-25 * time.Hour)
+	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a current marker
+	dt.Record("current text")
+
+	dt.Cleanup()
+
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Error("Old marker should have been cleaned up")
+	}
+	if !dt.IsDuplicate("current text") {
+		t.Error("Current marker should still exist")
+	}
+}

--- a/internal/voice/transcript.go
+++ b/internal/voice/transcript.go
@@ -100,7 +100,7 @@ func (tr *TranscriptReader) getMessageSimple(file *os.File) (string, error) {
 		if msg.Type == "assistant" && msg.Message.Role == "assistant" {
 			// Find first text content
 			for _, content := range msg.Message.Content {
-				if content.Type == "text" && content.Text != "" {
+				if content.Type == "text" && strings.TrimSpace(content.Text) != "" {
 					log.Debug().Str("text_length", fmt.Sprintf("%d", len(content.Text))).Msg("Found assistant message")
 					return content.Text, nil
 				}
@@ -266,8 +266,9 @@ func (tr *TranscriptReader) ProcessText(text string) string {
 	switch normalizedMode {
 	case ModeShort:
 		// First line only (formerly first_line)
+		text = strings.TrimSpace(text)
 		if idx := strings.Index(text, "\n"); idx != -1 {
-			text = text[:idx]
+			text = strings.TrimSpace(text[:idx])
 		}
 
 	case ModeFull:


### PR DESCRIPTION
## Summary

- Stop hook で音声合成が `text cannot be empty` エラーでクラッシュする問題を修正
- 同じメッセージが重複して読み上げられる問題を、セッション単位の dedup で解決
- `SubagentStop` イベントを音声合成の対象から除外

## 変更内容

### 空テキストエラーの修正
- `getMessageSimple` でホワイトスペースのみのメッセージをスキップ (`TrimSpace` 判定)
- `ProcessText` の short モードで先に `TrimSpace` してから改行分割
- `handleVoice` / `handleCodexAgentTurnComplete` に空テキストガード追加

### 読み上げ重複の防止
- `internal/voice/dedup.go`: セッション単位で読み上げ済みテキストの SHA-256 ハッシュを `/tmp/ccpersona-voice/` に記録
- 同一セッションで同じテキストの再読み上げをスキップ
- 24時間経過した古いマーカーの自動クリーンアップ

### SubagentStop の除外
- サブエージェント終了時の Stop イベントは音声合成をスキップ（重複の原因の一つ）

### notify コマンドの Stop hook 実装
- `handleVoiceSynthesisForEvent` (スタブ) を `handleStopEventVoice` として実装
- Cursor の `afterAgentResponse` 用に `handleDirectResponseVoice` を追加

## Test plan

- [x] `go vet ./...` パス
- [x] `go test ./internal/voice/ ./internal/hook/` 全テストパス
- [x] dedup テスト: 重複判定、セッション分離、上書き、クリーンアップ
- [ ] 実環境で Stop hook 実行時に空テキストエラーが出ないことを確認
- [ ] 同じセッションで同じメッセージが重複して読み上げられないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)