### PR TITLE
fix: resolve errcheck lint issues and add golangci-lint config

### DIFF
--- a/internal/voice/manager.go
+++ b/internal/voice/manager.go
@@ -267,7 +267,9 @@ func (vm *VoiceManager) synthesizeCloud(ctx context.Context, text string, option
 			return "", fmt.Errorf("failed to create temp file: %w", err)
 		}
 		outputPath = tmpFile.Name()
-		tmpFile.Close()
+		if err := tmpFile.Close(); err != nil {
+			return "", fmt.Errorf("failed to close temp file: %w", err)
+		}
 	}
 
 	// Write audio data to file

--- a/internal/voice/provider/factory_test.go
+++ b/internal/voice/provider/factory_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,14 +34,7 @@ func TestCreateProvider_OpenAI(t *testing.T) {
 	factory := NewFactory()
 
 	t.Run("fails without API key", func(t *testing.T) {
-		// Ensure env var is not set
-		originalKey := os.Getenv("OPENAI_API_KEY")
-		os.Unsetenv("OPENAI_API_KEY")
-		defer func() {
-			if originalKey != "" {
-				os.Setenv("OPENAI_API_KEY", originalKey)
-			}
-		}()
+		t.Setenv("OPENAI_API_KEY", "")
 
 		_, err := factory.CreateProvider("openai", map[string]interface{}{})
 		assert.Error(t, err)
@@ -60,15 +52,7 @@ func TestCreateProvider_OpenAI(t *testing.T) {
 	})
 
 	t.Run("succeeds with API key in env", func(t *testing.T) {
-		originalKey := os.Getenv("OPENAI_API_KEY")
-		os.Setenv("OPENAI_API_KEY", "test-env-api-key")
-		defer func() {
-			if originalKey != "" {
-				os.Setenv("OPENAI_API_KEY", originalKey)
-			} else {
-				os.Unsetenv("OPENAI_API_KEY")
-			}
-		}()
+		t.Setenv("OPENAI_API_KEY", "test-env-api-key")
 
 		provider, err := factory.CreateProvider("openai", map[string]interface{}{})
 		assert.NoError(t, err)
@@ -80,13 +64,7 @@ func TestCreateProvider_ElevenLabs(t *testing.T) {
 	factory := NewFactory()
 
 	t.Run("fails without API key", func(t *testing.T) {
-		originalKey := os.Getenv("ELEVENLABS_API_KEY")
-		os.Unsetenv("ELEVENLABS_API_KEY")
-		defer func() {
-			if originalKey != "" {
-				os.Setenv("ELEVENLABS_API_KEY", originalKey)
-			}
-		}()
+		t.Setenv("ELEVENLABS_API_KEY", "")
 
 		_, err := factory.CreateProvider("elevenlabs", map[string]interface{}{})
 		assert.Error(t, err)
@@ -154,15 +132,7 @@ func TestGetProviderWithDefaults(t *testing.T) {
 	factory := NewFactory()
 
 	t.Run("openai with defaults", func(t *testing.T) {
-		originalKey := os.Getenv("OPENAI_API_KEY")
-		os.Setenv("OPENAI_API_KEY", "test-key")
-		defer func() {
-			if originalKey != "" {
-				os.Setenv("OPENAI_API_KEY", originalKey)
-			} else {
-				os.Unsetenv("OPENAI_API_KEY")
-			}
-		}()
+		t.Setenv("OPENAI_API_KEY", "test-key")
 
 		provider, err := factory.GetProviderWithDefaults("openai")
 		assert.NoError(t, err)
@@ -188,15 +158,7 @@ func TestGetProviderWithDefaults(t *testing.T) {
 	})
 
 	t.Run("elevenlabs with defaults", func(t *testing.T) {
-		originalKey := os.Getenv("ELEVENLABS_API_KEY")
-		os.Setenv("ELEVENLABS_API_KEY", "test-key")
-		defer func() {
-			if originalKey != "" {
-				os.Setenv("ELEVENLABS_API_KEY", originalKey)
-			} else {
-				os.Unsetenv("ELEVENLABS_API_KEY")
-			}
-		}()
+		t.Setenv("ELEVENLABS_API_KEY", "test-key")
 
 		provider, err := factory.GetProviderWithDefaults("elevenlabs")
 		assert.NoError(t, err)

--- a/internal/voice/provider/gcp_test.go
+++ b/internal/voice/provider/gcp_test.go
@@ -10,6 +10,7 @@ import (
 	"cloud.google.com/go/texttospeech/apiv1/texttospeechpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -282,8 +283,8 @@ func TestGCPProvider_Integration(t *testing.T) {
 		reader, err := p.Synthesize(ctx, "こんにちは、世界！", SynthesizeOptions{
 			Format: "mp3",
 		})
-		assert.NoError(t, err)
-		assert.NotNil(t, reader)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
 		defer func() { _ = reader.Close() }()
 
 		// Read the audio data
@@ -299,8 +300,8 @@ func TestGCPProvider_Integration(t *testing.T) {
 			Speed:  1.5,
 			Format: "mp3",
 		})
-		assert.NoError(t, err)
-		assert.NotNil(t, reader)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
 		defer func() { _ = reader.Close() }()
 
 		data, err := io.ReadAll(reader)
@@ -313,8 +314,8 @@ func TestGCPProvider_Integration(t *testing.T) {
 		reader, err := p.Synthesize(ctx, ssml, SynthesizeOptions{
 			Format: "mp3",
 		})
-		assert.NoError(t, err)
-		assert.NotNil(t, reader)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
 		defer func() { _ = reader.Close() }()
 
 		data, err := io.ReadAll(reader)


### PR DESCRIPTION
## Summary

- Add `.golangci.yml` (v2 format) with `errcheck` exclude-functions for best-effort cleanup patterns (`defer Close()`, `os.Remove`, `os.RemoveAll`, `os.Setenv`, `os.Unsetenv`)
- Fix non-defer unchecked error: `tmpFile.Close()` in `internal/voice/manager.go`
- Replace manual `os.Setenv`/`os.Unsetenv` with `t.Setenv` in `internal/voice/provider/factory_test.go` (Go 1.17+ idiomatic)
- Fix nil pointer dereference in `internal/voice/provider/gcp_test.go` by using `require` instead of `assert` for error/nil checks before `defer reader.Close()`

Reduces golangci-lint errcheck issues from **17 to 0**.

## Test plan

- [ ] `golangci-lint run ./...` returns 0 issues
- [ ] `go test ./internal/voice/...` passes (excluding GCP integration test which requires credentials)
- [ ] `go test ./internal/voice/provider/... -run TestCreateProvider` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)