### PR TITLE
feat: voice synthesis mute/unmute global gate

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,6 +115,11 @@ and behavioral patterns for your AI assistant.`,
 				Flags: []cli.Flag{
 					// Input mode flags
 					&cli.BoolFlag{
+						Name:  "force",
+						Usage: "Bypass the global mute gate for this invocation",
+						Value: false,
+					},
+					&cli.BoolFlag{
 						Name:  "transcript",
 						Usage: "Read from Claude Code transcript instead of stdin",
 						Value: false,
@@ -165,6 +170,28 @@ and behavioral patterns for your AI assistant.`,
 					},
 				},
 				Commands: []*cli.Command{
+					{
+						Name:   "mute",
+						Usage:  "Globally disable voice synthesis across all paths",
+						Action: handleVoiceMute,
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:  "reason",
+								Usage: "Optional note stored alongside the mute marker",
+								Value: "",
+							},
+						},
+					},
+					{
+						Name:   "unmute",
+						Usage:  "Lift the global voice synthesis mute",
+						Action: handleVoiceUnmute,
+					},
+					{
+						Name:   "status",
+						Usage:  "Show the current global mute state",
+						Action: handleVoiceStatus,
+					},
 					{
 						Name:  "config",
 						Usage: "Manage voice configuration",

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -175,6 +175,10 @@ func handleCodexAgentTurnComplete(ctx context.Context, c *cli.Command, event *ho
 
 	// Voice notification (if enabled)
 	if c.Bool("voice") && codexEvent.LastAssistantMessage != "" {
+		if voice.IsMuted() {
+			log.Debug().Msg("voice synthesis is globally muted, skipping Codex turn voice")
+			return nil
+		}
 		fileConfig := loadVoiceConfig(c)
 		config, _ := persona.LoadConfigWithFallbackForPlatform(event.Source)
 		opts := voice.Resolve(toPersonaVoiceInput(config), fileConfig, "")
@@ -226,6 +230,11 @@ func handleStopEventVoice(ctx context.Context, c *cli.Command, event *hook.Unifi
 		if debug {
 			fmt.Fprintf(os.Stderr, "[DEBUG] Voice flag not set, skipping voice synthesis\n")
 		}
+		return nil
+	}
+
+	if voice.IsMuted() {
+		log.Debug().Msg("voice synthesis is globally muted, skipping Stop event voice")
 		return nil
 	}
 
@@ -335,6 +344,11 @@ func handleDirectResponseVoice(ctx context.Context, c *cli.Command, event *hook.
 		return nil
 	}
 
+	if voice.IsMuted() {
+		log.Debug().Msg("voice synthesis is globally muted, skipping direct-response voice")
+		return nil
+	}
+
 	text := event.AIResponse
 	if text == "" {
 		if debug {
@@ -414,6 +428,10 @@ func handleNotificationEvent(ctx context.Context, c *cli.Command, event *hook.Un
 
 	// Voice notification
 	if c.Bool("voice") {
+		if voice.IsMuted() {
+			log.Debug().Msg("voice synthesis is globally muted, skipping notification voice")
+			return nil
+		}
 		fileConfig := loadVoiceConfig(c)
 		config, _ := persona.LoadConfigWithFallbackForPlatform(event.Source)
 		opts := voice.Resolve(toPersonaVoiceInput(config), fileConfig, "")

--- a/cmd/voice.go
+++ b/cmd/voice.go
@@ -17,6 +17,11 @@ import (
 )
 
 func handleVoice(ctx context.Context, c *cli.Command) error {
+	if !c.Bool("force") && voice.IsMuted() {
+		log.Debug().Msg("voice synthesis is globally muted, skipping")
+		return nil
+	}
+
 	fileConfig := loadVoiceConfig(c)
 
 	personaConfig, err := persona.LoadConfigWithFallback()
@@ -332,6 +337,59 @@ func handleVoiceConfigInit(ctx context.Context, c *cli.Command) error {
 	fmt.Println("\nEdit the file to configure your preferred voice providers.")
 	fmt.Println("Use ${ENV_VAR} syntax for sensitive values like API keys.")
 
+	return nil
+}
+
+// Voice mute gate handlers
+
+func handleVoiceMute(ctx context.Context, c *cli.Command) error {
+	status, err := voice.Mute(c.String("reason"))
+	if err != nil {
+		return fmt.Errorf("failed to enable mute: %w", err)
+	}
+	path, _ := voice.MutePath()
+	fmt.Printf("🔇 Voice synthesis muted globally.\n")
+	fmt.Printf("   Marker : %s\n", path)
+	fmt.Printf("   At     : %s\n", status.MutedAt.Format("2006-01-02 15:04:05 MST"))
+	if status.Reason != "" {
+		fmt.Printf("   Reason : %s\n", status.Reason)
+	}
+	fmt.Println("\nRun 'ccpersona voice unmute' to re-enable, or pass --force to bypass for one call.")
+	return nil
+}
+
+func handleVoiceUnmute(ctx context.Context, c *cli.Command) error {
+	wasMuted := voice.IsMuted()
+	if err := voice.Unmute(); err != nil {
+		return fmt.Errorf("failed to disable mute: %w", err)
+	}
+	if wasMuted {
+		fmt.Println("🔊 Voice synthesis unmuted.")
+	} else {
+		fmt.Println("🔊 Voice synthesis was not muted; nothing to do.")
+	}
+	return nil
+}
+
+func handleVoiceStatus(ctx context.Context, c *cli.Command) error {
+	status, err := voice.LoadMuteStatus()
+	if err != nil {
+		return fmt.Errorf("failed to read mute status: %w", err)
+	}
+	if status == nil {
+		fmt.Println("🔊 Voice synthesis: ACTIVE (not muted)")
+		return nil
+	}
+
+	path, _ := voice.MutePath()
+	fmt.Println("🔇 Voice synthesis: MUTED")
+	fmt.Printf("   Marker : %s\n", path)
+	if !status.MutedAt.IsZero() {
+		fmt.Printf("   Since  : %s\n", status.MutedAt.Local().Format("2006-01-02 15:04:05 MST"))
+	}
+	if status.Reason != "" {
+		fmt.Printf("   Reason : %s\n", status.Reason)
+	}
 	return nil
 }
 

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -48,6 +48,11 @@ func (s *SpeakService) Speak(ctx context.Context, req SpeakRequest) error {
 		return fmt.Errorf("text cannot be empty")
 	}
 
+	if voice.IsMuted() {
+		log.Debug().Msg("voice synthesis is globally muted, skipping MCP speak")
+		return nil
+	}
+
 	// Resolve project directory for persona/voice config lookup.
 	projectDir := req.ProjectDir
 	if projectDir == "" {

--- a/internal/mcp/service_test.go
+++ b/internal/mcp/service_test.go
@@ -162,6 +162,26 @@ func TestSpeakService_Speak_WithPersonaVoiceConfig(t *testing.T) {
 	assert.Equal(t, 42, synth.lastOpts.AivisSpeechSpeaker)
 }
 
+func TestSpeakService_Speak_SkipsWhenMuted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, err := voice.Mute("test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = voice.Unmute() })
+
+	synth := &mockSynthesizer{returnPath: "/tmp/voice_test.mp3"}
+	player := &mockPlayer{}
+
+	svc := internalmcp.NewSpeakService(synth, player)
+	err = svc.Speak(context.Background(), internalmcp.SpeakRequest{
+		Text:       "muted",
+		ProjectDir: t.TempDir(),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, synth.called, "Synthesize must NOT be called while globally muted")
+	assert.False(t, player.called, "Playback must NOT be attempted while globally muted")
+}
+
 func TestSpeakService_Speak_EmptyAudioPath(t *testing.T) {
 	// Synthesize returns an empty path (e.g., ToStdout case) — playback should still be attempted.
 	synth := &mockSynthesizer{returnPath: ""}

--- a/internal/voice/manager_test.go
+++ b/internal/voice/manager_test.go
@@ -97,7 +97,7 @@ func TestSynthesizeLocalNoRace(t *testing.T) {
 			defer wg.Done()
 			// synthesizeLocal will fail to reach a real engine, but the race
 			// detector will catch any concurrent writes to vm.config.
-			_ , _ = manager.Synthesize(ctx, "test", VoiceOptions{Provider: p})
+			_, _ = manager.Synthesize(ctx, "test", VoiceOptions{Provider: p})
 		}(provider)
 	}
 

--- a/internal/voice/mute.go
+++ b/internal/voice/mute.go
@@ -1,0 +1,93 @@
+package voice
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// MuteStatus represents the global mute state snapshot.
+type MuteStatus struct {
+	MutedAt time.Time `json:"muted_at"`
+	Reason  string    `json:"reason,omitempty"`
+}
+
+// MutePath returns the absolute path to the mute marker file
+// (~/.claude/ccpersona/mute). The marker's existence means voice
+// synthesis is globally muted.
+func MutePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".claude", "ccpersona", "mute"), nil
+}
+
+// IsMuted reports whether global voice synthesis is currently muted.
+// Errors (e.g. missing HOME) are treated as "not muted" so the gate
+// fails open and does not break hook-driven callers.
+func IsMuted() bool {
+	path, err := MutePath()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(path)
+	return err == nil
+}
+
+// Mute enables the global mute. Idempotent: refreshes MutedAt and Reason.
+func Mute(reason string) (*MuteStatus, error) {
+	path, err := MutePath()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create mute dir: %w", err)
+	}
+	status := &MuteStatus{MutedAt: time.Now().UTC(), Reason: reason}
+	data, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal mute status: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return nil, fmt.Errorf("write mute file: %w", err)
+	}
+	return status, nil
+}
+
+// Unmute removes the mute marker. Idempotent when already unmuted.
+func Unmute() error {
+	path, err := MutePath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove mute file: %w", err)
+	}
+	return nil
+}
+
+// LoadMuteStatus returns the current mute status. Returns (nil, nil)
+// when not muted. When the marker file exists but is unparseable,
+// returns a zero-value status so callers still treat the session as muted.
+func LoadMuteStatus() (*MuteStatus, error) {
+	path, err := MutePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read mute file: %w", err)
+	}
+	var status MuteStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return &MuteStatus{}, nil
+	}
+	return &status, nil
+}

--- a/internal/voice/mute_test.go
+++ b/internal/voice/mute_test.go
@@ -1,0 +1,152 @@
+package voice
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMute_NotMutedByDefault(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if IsMuted() {
+		t.Fatal("expected IsMuted() == false on a fresh home")
+	}
+}
+
+func TestMute_SetsMarkerFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	status, err := Mute("focusing")
+	if err != nil {
+		t.Fatalf("Mute returned error: %v", err)
+	}
+	if status == nil {
+		t.Fatal("Mute returned nil status")
+	}
+	if status.Reason != "focusing" {
+		t.Errorf("Reason = %q, want %q", status.Reason, "focusing")
+	}
+	if status.MutedAt.IsZero() {
+		t.Error("MutedAt should be set")
+	}
+
+	if !IsMuted() {
+		t.Error("IsMuted() should return true after Mute()")
+	}
+
+	want := filepath.Join(home, ".claude", "ccpersona", "mute")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("expected mute file at %s: %v", want, err)
+	}
+}
+
+func TestMute_Idempotent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	first, err := Mute("a")
+	if err != nil {
+		t.Fatalf("first Mute: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	second, err := Mute("b")
+	if err != nil {
+		t.Fatalf("second Mute: %v", err)
+	}
+
+	if !second.MutedAt.After(first.MutedAt) {
+		t.Error("second Mute should refresh MutedAt to a later time")
+	}
+	if second.Reason != "b" {
+		t.Errorf("second Reason = %q, want %q", second.Reason, "b")
+	}
+}
+
+func TestUnmute_RemovesMarker(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if _, err := Mute(""); err != nil {
+		t.Fatalf("Mute: %v", err)
+	}
+	if !IsMuted() {
+		t.Fatal("precondition: should be muted")
+	}
+
+	if err := Unmute(); err != nil {
+		t.Fatalf("Unmute: %v", err)
+	}
+	if IsMuted() {
+		t.Error("IsMuted() should return false after Unmute()")
+	}
+}
+
+func TestUnmute_IdempotentWhenNotMuted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := Unmute(); err != nil {
+		t.Errorf("Unmute on non-muted state should succeed, got: %v", err)
+	}
+}
+
+func TestLoadMuteStatus_ReturnsNilWhenNotMuted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	status, err := LoadMuteStatus()
+	if err != nil {
+		t.Fatalf("LoadMuteStatus: %v", err)
+	}
+	if status != nil {
+		t.Errorf("expected nil status when not muted, got %+v", status)
+	}
+}
+
+func TestLoadMuteStatus_ReturnsStatusWhenMuted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if _, err := Mute("quiet hours"); err != nil {
+		t.Fatalf("Mute: %v", err)
+	}
+
+	status, err := LoadMuteStatus()
+	if err != nil {
+		t.Fatalf("LoadMuteStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected non-nil status")
+	}
+	if status.Reason != "quiet hours" {
+		t.Errorf("Reason = %q, want %q", status.Reason, "quiet hours")
+	}
+	if status.MutedAt.IsZero() {
+		t.Error("MutedAt should be populated")
+	}
+}
+
+func TestLoadMuteStatus_HandlesCorruptFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path := filepath.Join(home, ".claude", "ccpersona", "mute")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsMuted() {
+		t.Error("IsMuted() should rely on file existence, not content")
+	}
+
+	status, err := LoadMuteStatus()
+	if err != nil {
+		t.Fatalf("LoadMuteStatus on corrupt file should not error, got: %v", err)
+	}
+	if status == nil {
+		t.Error("LoadMuteStatus on corrupt file should return non-nil zero status (still muted)")
+	}
+}


### PR DESCRIPTION
## Summary

- 音声合成をグローバルに一時停止する `ccpersona voice mute` / `unmute` / `status` サブコマンドを追加
- マーカーファイル `~/.claude/ccpersona/mute` (JSON) で状態管理
- ミュート中は全ての発話経路 (voice CLI, notify の 4 経路, MCP speak) で静かに no-op exit 0
- 一時バイパス用に `ccpersona voice --force` フラグを追加

Closes #76

## Test plan

- [x] `go test ./internal/voice/... ./internal/mcp/...` でユニットテストが全て通る
- [x] `golangci-lint run ./...` で 0 issues
- [x] `ccpersona voice status` が未ミュート状態で `ACTIVE` を表示
- [x] `ccpersona voice mute --reason "focus"` でマーカー作成、`status` が `MUTED` + 理由 + 時刻を表示
- [x] ミュート中の `echo hello | ccpersona voice --plain` が無音で exit 0
- [x] ミュート中の `echo hello | ccpersona voice --force --plain --output <file>` で発話されて wav 出力される
- [x] `ccpersona voice unmute` で解除、`status` が `ACTIVE` に戻る
- [x] `ccpersona voice unmute` を未ミュート状態で再実行しても冪等
- [x] マーカーファイルが壊れていても IsMuted が true を維持（fail closed）
- [ ] (要ユーザー実施) 実際の Claude Code / Codex / Cursor hook 経由で stop/notify 時の無音動作を確認
- [ ] (要ユーザー実施) MCP speak ツールをミュート中に呼んでスキップされることを確認